### PR TITLE
mycnfを作成＆systemctlの登録が成功するように修正

### DIFF
--- a/setup_mysql.sh
+++ b/setup_mysql.sh
@@ -52,6 +52,13 @@ if [ "$1" = '--init' ]; then
 
   cp /usr/local/mysql/support-files/mysql.server /etc/init.d/mysqld
   chmod 744 /etc/init.d/mysqld
+  touch /etc/my.cnf
+  cat <<EOF > /etc/my.cnf
+[mysqld]
+socket=/var/run/mysqld/mysqld.sock
+[client]
+socket=/var/run/mysqld/mysqld.sock
+EOF
   $mysql_install_path/bin/mysqld --datadir=/usr/local/mysql/data --basedir=/usr/local/mysql --user=mysql --log-error-verbosity=3 --initialize-insecure
 
   # 自動起動登録

--- a/setup_mysql.sh
+++ b/setup_mysql.sh
@@ -50,6 +50,7 @@ if [ "$1" = '--init' ]; then
   useradd mysql -s /bin/false
   chown -R mysql:mysql $mysql_install_path
 
+  cp /usr/local/mysql/support-files/mysql.server /etc/init.d/mysqld
   chmod 744 /etc/init.d/mysqld
   $mysql_install_path/bin/mysqld --datadir=/usr/local/mysql/data --basedir=/usr/local/mysql --user=mysql --log-error-verbosity=3 --initialize-insecure
 


### PR DESCRIPTION
# 修正内容
- `systemctl enable mysql`実行時に`/etc/init.d/mysqld`が存在しないために、serviceへの登録が失敗していたので、`/usr/local/mysql/support-files/`のmysql.serverを`/etc/init.d/mysqld`においてあげることでserviceへの登録ができるように修正しました。
- mysql起動後、socketの指定がないために`mysql -uroot`で失敗していたのでmycnfを作成し、ログインできるようにしました。

以上の二点を修正しました。レビューよろしくお願いします。